### PR TITLE
Registration flow creates user with appropriate group

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/truevault@0.2.0/build/index.js"></script>
+    <script src="https://unpkg.com/truevault@0.4.0/build/index.js"></script>
     <script src="tv_config.js"></script>
     <script src="index.js"></script>
   </body>

--- a/index.js
+++ b/index.js
@@ -24,8 +24,7 @@ async function loginUser(username, password, mfaCode){
 }
 
 async function registerUser(username, password) {
-    tvUser = await createUserTvClient.createUser(username, password);
-    await createUserTvClient.addUsersToGroup(TV_CREDENTIALS.GROUP_ID, [tvUser.id]);
+    tvUser = await createUserTvClient.createUser(username, password, {}, [TV_CREDENTIALS.GROUP_ID]);
     tvUserClient = new TrueVaultClient(tvUser.access_token);
 }
 


### PR DESCRIPTION
Avoid extra request to add new user to group, by using the `group_ids` parameter of the create user endpoint. See https://docs.truevault.com/users#create-a-user for details.