### PR TITLE
Add support for user password reset emails.

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
           <li><a class="auth-link" href="#user_settings">User Settings</a></li>
           <li><a class="unauth-link" href="#sign_in">Sign In</a></li>
           <li><a class="unauth-link" href="#sign_up">Sign Up</a></li>
+          <li><a class="unauth-link" href="send-reset-password-email.html">Forgot Password</a></li>
         </ul>
       </div><!--/.nav-collapse -->
     </div>
@@ -150,7 +151,7 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/truevault@0.2.0/build/index.js"></script>
+    <script src="https://unpkg.com/truevault@0.5.0/build/index.js"></script>
     <script src="tv_config.js"></script>
     <script src="index.js"></script>
   </body>

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const mfaCodeRowEl = document.getElementById("mfa-code-row");
 const unenrollMFAFormEl = document.getElementById("unenroll-mfa-form");
 const startMFAEl = document.getElementById("start-mfa");
 
-const createUserTvClient = new TrueVaultClient(TV_CREDENTIALS.CREATE_USER_API_KEY);
+const createUserTvClient = new TrueVaultClient({apiKey: TV_CREDENTIALS.CREATE_USER_API_KEY});
 let tvUser;
 let tvUserClient;
 let tasksDocumentId;

--- a/reset-password-link-clicked.html
+++ b/reset-password-link-clicked.html
@@ -1,0 +1,52 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="https://unpkg.com/truevault@0.5.0/build/index.js"></script>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="index.css">
+
+</head>
+<body>
+<div class="container">
+  <p>Please enter your new password:</p>
+  <form id="change-password-form" class="form-horizontal">
+    <div class="form-group">
+      <label for="password" class="col-sm-2 control-label">New Password</label>
+      <div class="col-sm-10">
+
+        <input type="password" id="password" name="password">
+      </div>
+    </div>
+    <div class="col-sm-offset-2 col-sm-10">
+      <button type="submit" class="btn btn-default">Update Password</button>
+    </div>
+  </form>
+
+</div>
+</body>
+<script>
+    const resetFormEl = document.getElementById("change-password-form");
+    const hashParams = location.hash.substr(1).split('&');
+    const parsedParams = {};
+    for (var i = 0; i < hashParams.length; i++) {
+        const keyValue = hashParams[i].split('=');
+        const key = decodeURIComponent(keyValue[0]);
+        const value = decodeURIComponent(keyValue[1]);
+        parsedParams[key] = value;
+    }
+
+    resetFormEl.addEventListener("submit", async e => {
+        e.preventDefault();
+
+        const tvClient = new TrueVaultClient({httpBasic: parsedParams.httpAuth});
+
+        try {
+            await tvClient.updateUserPassword(parsedParams.userId, this.password.value);
+            alert("Success!");
+        } catch (e) {
+            alert("Error changing password");
+        }
+    });
+</script>
+</html>

--- a/send-reset-password-email.html
+++ b/send-reset-password-email.html
@@ -1,0 +1,46 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="https://unpkg.com/truevault@0.5.0/build/index.js"></script>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+  <link rel="stylesheet" href="index.css">
+
+</head>
+<body>
+<div class="container">
+  <p>Forgot your password? Enter your username and we'll send you a password reset link.</p>
+  <form id="reset-form" class="form-horizontal">
+    <div class="form-group">
+      <label for="username" class="col-sm-2 control-label">Username</label>
+      <div class="col-sm-10">
+        <input type="text" id="username" name="username" placeholder="joe@example.com" class="form-control">
+      </div>
+    </div>
+    <div class="form-group">
+      <div class="col-sm-offset-2 col-sm-10">
+        <button type="submit" id="pw-reset-submit" class="btn btn-default">Send Reset Email</button>
+      </div>
+    </div>
+  </form>
+</div>
+</body>
+<script>
+    const resetFormEl = document.getElementById("reset-form");
+    const scopedAccessTokenAuth = 'REPLACE ME WITH TOKEN FROM PASSWORD RESET FLOW';
+    const passwordResetFlowId = 'REPLACE ME WITH FLOW ID FROM PASSWORD RESET FLOW';
+
+    resetFormEl.addEventListener("submit", async e => {
+        e.preventDefault();
+
+        const tvClient = new TrueVaultClient({httpBasic: scopedAccessTokenAuth});
+
+        try {
+            await tvClient.sendPasswordResetEmail(passwordResetFlowId, this.username.value);
+            alert("Success!");
+        } catch (e) {
+            alert("Error sending password reset email");
+        }
+    });
+</script>
+</html>


### PR DESCRIPTION
To use this, you would need to drop in appropriate info for a configured
reset flow.

If you want clickable links, you'll need to configure the email template
used in the password reset flow to create links that point to wherever
you're hosting this sample app. If you're OK with a little copy and
paste for testing, simply copy the URL fragment out of the link received
in the email and append that to the URL where the
"reset password link clicked" page is hosted (i.e. local dev).

For more info about password reset, see [this guide](https://www.truevault.com/resources/developer/how-do-I-implement-user-forgot-password.html).